### PR TITLE
cacheprovider can run without servletcontext (breaks in XPM cases), moni...

### DIFF
--- a/dd4t-core/src/main/java/org/dd4t/core/caching/impl/EHCacheProvider.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/caching/impl/EHCacheProvider.java
@@ -100,8 +100,7 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator,
 	 */
 	@Override
 	public <T> CacheElement<T> loadPayloadFromLocalCache(String key) {
-		String sessionPreviewToken = TridionUtils.getSessionPreviewToken();
-		if (!doCheckForPreview() || (sessionPreviewToken == null && cache != null)) {
+		if (!doCheckForPreview() || (TridionUtils.getSessionPreviewToken() == null && cache != null)) {
 			Element currentElement = cache.get(key);
 			if (currentElement == null) {
 				currentElement = new Element(key, new CacheElementImpl<T>(null));
@@ -126,7 +125,7 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator,
 			return cacheElement;
 		} else {
 			LOG.debug("Disable cache for Preview Session Token: {}",
-					sessionPreviewToken);
+					TridionUtils.getSessionPreviewToken());
 			return new CacheElementImpl<T>((T) null, true);
 		}
 	}

--- a/dd4t-core/src/main/java/org/dd4t/core/caching/impl/JMSCacheMessageListener.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/caching/impl/JMSCacheMessageListener.java
@@ -36,6 +36,7 @@ public class JMSCacheMessageListener implements MessageListener {
                     LOG.debug("Invalidate " + event);
                     Serializable key = event.getKey();
                     cacheInvalidator.invalidate(key.toString());
+                    monitor.setMQServerStatusUp();
                     break;
 
                 case CacheEvent.FLUSH:

--- a/dd4t-core/src/main/java/org/dd4t/core/caching/impl/JMSCacheMonitor.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/caching/impl/JMSCacheMonitor.java
@@ -1,5 +1,7 @@
 package org.dd4t.core.caching.impl;
 
+import javax.annotation.PostConstruct;
+
 import org.dd4t.core.caching.CacheInvalidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,19 +47,21 @@ public class JMSCacheMonitor {
         }
     };
 
-    private final Thread thread;
+    private Thread thread;
 
-    private JMSCacheMonitor () {
+    @PostConstruct
+    public void init(){
         LOG.debug("Create new instance");
 
         LOG.debug("Using Monitor interval (or cache refresh time when JMS is down) = {} seconds", monitorServiceInterval, monitorServiceInterval / 1000);
-
-        LOG.debug("Start cache monitor thread");
         thread = new Thread(monitor);
         thread.setName("Dd4tWebAppJMSMonitorThread");
+        
+        LOG.debug("Start cache monitor thread");
+
         thread.start();
     }
-
+    
     public int getMonitorServiceInterval() {
 		return monitorServiceInterval;
 	}


### PR DESCRIPTION
...tor accepts spring-injected monitor time, listener flags JMS as up when a cache invalidation message comes in
