### PR TITLE
TCMURI refactor with Builder pattern

### DIFF
--- a/dd4t-api/src/main/java/org/dd4t/core/util/TCMURI.java
+++ b/dd4t-api/src/main/java/org/dd4t/core/util/TCMURI.java
@@ -49,7 +49,7 @@ public class TCMURI implements Serializable {
                 .version(version));
     }
 
-    public TCMURI(Builder builder) {
+    private TCMURI(Builder builder) {
         this.itemType = builder.itemType;
         this.itemId = builder.itemId;
         this.pubId = builder.pubId;

--- a/dd4t-api/src/main/java/org/dd4t/core/util/TCMURI.java
+++ b/dd4t-api/src/main/java/org/dd4t/core/util/TCMURI.java
@@ -31,27 +31,21 @@ public class TCMURI implements Serializable {
     protected int pubId;
     protected int version;
 
-    @Deprecated
-    public TCMURI() {
-    }
-
-    @Deprecated
     public TCMURI(String uri) throws ParseException {
         this(new Builder(uri));
     }
 
-    //added because of custom code, next release can be deleted?
-    @Deprecated
     public TCMURI(String uri, int version) throws ParseException {
         this(new Builder(uri)
                 .version(version));
     }
 
-    //make it private instead of delete on next release
-    @Deprecated
+    public TCMURI(int publicationId, int itemId, int itemType) {
+        this(new Builder(publicationId,itemId, itemType));
+    }
+
     public TCMURI(int publicationId, int itemId, int itemType, int version) {
-        this(new Builder(publicationId, itemId)
-                .itemType(itemType)
+        this(new Builder(publicationId, itemId, itemType)
                 .version(version));
     }
 
@@ -66,7 +60,6 @@ public class TCMURI implements Serializable {
         return tcmUri != null && tcmUri.startsWith(URI_NAMESPACE);
     }
 
-    @Deprecated
     protected void load(String uriString) throws ParseException {
         Builder builder = new Builder(uriString);
         this.itemType = builder.itemType;
@@ -114,9 +107,20 @@ public class TCMURI implements Serializable {
         private int itemType = 16;
         private int version = -1;
 
+	    /**
+         * Defaults to ItemType component
+         * @param pubId the publication Id
+         * @param itemId the item Id
+         */
         public Builder(int pubId, int itemId) {
             this.pubId = pubId;
             this.itemId = itemId;
+        }
+
+        public Builder(int pubId, int itemId, int itemType) {
+            this.pubId = pubId;
+            this.itemId = itemId;
+            this.itemType = itemType;
         }
 
         public Builder(String uri) throws ParseException {

--- a/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
+++ b/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
@@ -1,48 +1,178 @@
 package org.dd4t.core.util;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
 import java.text.ParseException;
 
-public class TCMURITest extends TestCase{
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
 
-    public static final int PUBLICATION_ID = 12;
-    public static final int ITEM_ID = 14;
-    public static final int ITEM_TYPE = 16;
-    public static final int VERSION = 2;
-    public static final String EXPECTED = "tcm:12-14-16";
+public class TCMURITest {
 
-    @Test
-    public void testToString() throws ParseException {
-        TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
-        assertEquals(EXPECTED, tcmUri.toString());
+    private static final int PUBLICATION_ID = 12;
+    private static final int ITEM_ID = 14;
+    private static final int ITEM_TYPE = 5;
+    private static final int VERSION = 2;
 
-        TCMURI tcmUriByString = new TCMURI(EXPECTED);
-        assertEquals(EXPECTED, tcmUriByString.toString());
+    private static final int DEFAULT_VERSION = -1;
+    private static final int DEFAULT_ITEM_TYPE = 16;
+
+    private final TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+
+    @Test public void
+    convert_to_string_using_format() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE);
+
+        assertThat(tcmUri.toString(), is(uri));
+        assertThat(new TCMURI(uri).toString(), is(uri));
     }
 
-    @Test
-    public void testGetItemType() throws ParseException {
-        TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+    @Test public void
+    return_item_type() {
         assertEquals(ITEM_TYPE, tcmUri.getItemType());
     }
 
-    @Test
-    public void testGetItemId() throws ParseException {
-        TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+    @Test public void
+    return_item_id() {
         assertEquals(ITEM_ID, tcmUri.getItemId());
     }
 
-    @Test
-    public void testGetPublicationId() throws ParseException {
-        TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+    @Test public void
+    return_publication_id() {
         assertEquals(PUBLICATION_ID, tcmUri.getPublicationId());
     }
 
-    @Test
-    public void testGetVersion() throws ParseException {
-        TCMURI tcmUri = new TCMURI(PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+    @Test public void
+    return_version() {
         assertEquals(VERSION, tcmUri.getVersion());
+    }
+
+    @Test public void
+    tcmUri_be_valid() {
+        assertThat(TCMURI.isValid(tcmUri.toString()), is(true));
+    }
+
+    @Test public void
+    throws_exception_when_uri_is_null() {
+        try {
+            new TCMURI().load(null);
+            fail("Exception expected");
+        } catch (ParseException e) {
+            assertThat(e.getMessage(), is("Invalid TCMURI String, string cannot be null"));
+            assertThat(e.getErrorOffset(), is(0));
+        }
+    }
+
+    @Test public void
+    throws_exception_when_uri_has_wrong_format() {
+        final String uri = String.format("wrong:%s-%s-%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE);
+
+        try {
+            new TCMURI().load(uri);
+            fail("Exception expected");
+        } catch (ParseException e) {
+            assertThat(e.getMessage(), is(String.format("URI string %s does not start with %s", uri, TCMURI.URI_NAMESPACE)));
+        }
+    }
+
+    @Test public void
+    throws_exception_when_uri_has_only_publication_id() {
+        final String uri = String.format("tcm:%s#bad", PUBLICATION_ID);
+
+        try {
+            new TCMURI().load(uri);
+            fail("Exception expected");
+        } catch (ParseException e) {
+            assertThat(e.getMessage(), is(String.format("URI %s does not match the pattern", uri)));
+        }
+    }
+
+    @Test public void
+    build_with_only_mandatory_parameters_and_put_default() throws ParseException {
+        final String uri = String.format("tcm:%s-%s", PUBLICATION_ID, ITEM_ID);
+
+        TCMURI tcmUri = new TCMURI();
+        tcmUri.load(uri);
+
+        assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
+        assertThat(tcmUri.getItemId(), is(ITEM_ID));
+        assertThat(tcmUri.getItemType(), is(DEFAULT_ITEM_TYPE));
+        assertThat(tcmUri.getVersion(), is(DEFAULT_VERSION));
+    }
+
+    @Test public void
+    throws_exception_when_publication_id_is_not_a_number() {
+        final String uri = String.format("tcm:%s-%s-%s", "aString", ITEM_ID, ITEM_TYPE);
+
+        try {
+            new TCMURI().load(uri);
+            fail("Exception expected");
+        } catch (ParseException e) {
+            assertThat(e.getMessage(), is(String.format("URI %s does not match the pattern", uri)));
+        }
+    }
+
+    @Test public void
+    return_item_type_16_when_is_not_part_of_URI() throws ParseException {
+        final String uri = String.format("tcm:%s-%s", PUBLICATION_ID, ITEM_ID);
+
+        TCMURI tcmUri = new TCMURI(uri);
+        assertThat(tcmUri.getItemType(), is(16));
+    }
+
+    @Test public void
+    return_version_when_is_part_of_uri() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-%s-v%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+
+        TCMURI tcmUri = new TCMURI(uri);
+        assertThat(tcmUri.getItemType(), is(ITEM_TYPE));
+        assertThat(tcmUri.getVersion(), is(VERSION));
+    }
+
+    @Test public void
+    return_version_and_item_type_16_when_uri_has_version_but_not_item_type() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-v%s", PUBLICATION_ID, ITEM_ID, VERSION);
+
+        TCMURI tcmUri = new TCMURI(uri);
+        assertThat(tcmUri.getItemType(), is(16));
+        assertThat(tcmUri.getVersion(), is(VERSION));
+    }
+
+    @Test(expected = IllegalArgumentException.class) public void
+    throws_exception_when_long_can_not_be_converted_to_int() {
+        TCMURI.safeLongToInt(Long.MAX_VALUE);
+        TCMURI.safeLongToInt(Long.MIN_VALUE);
+    }
+
+    @Test public void
+    create_tcmUri_with_builder() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-%s-v%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+
+        TCMURI tcmUri = new TCMURI.Builder().with(uri).create();
+
+        assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
+        assertThat(tcmUri.getItemId(), is(ITEM_ID));
+        assertThat(tcmUri.getItemType(), is(ITEM_TYPE));
+        assertThat(tcmUri.getVersion(), is(VERSION));
+    }
+
+    @Test public void
+    create_tcm_uri_with_builder_overwrite_version_from_url() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-%s-v%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
+        final int version = 4;
+
+        TCMURI tcmUri = new TCMURI.Builder().with(uri).version(version).create();
+
+        assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
+        assertThat(tcmUri.getItemId(), is(ITEM_ID));
+        assertThat(tcmUri.getItemType(), is(ITEM_TYPE));
+        assertThat(tcmUri.getVersion(), is(version));
+    }
+
+
+    @Test public void
+    convert_safely_long_to_int() {
+        assertThat(TCMURI.safeLongToInt(Integer.MAX_VALUE),
+                is(Integer.MAX_VALUE));
     }
 }

--- a/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
+++ b/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
@@ -55,7 +55,7 @@ public class TCMURITest {
     @Test public void
     throws_exception_when_uri_is_null() {
         try {
-            new TCMURI().load(null);
+            new TCMURI(null);
             fail("Exception expected");
         } catch (ParseException e) {
             assertThat(e.getMessage(), is("Invalid TCMURI String, string cannot be null"));
@@ -68,7 +68,7 @@ public class TCMURITest {
         final String uri = String.format("wrong:%s-%s-%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE);
 
         try {
-            new TCMURI().load(uri);
+            new TCMURI(uri);
             fail("Exception expected");
         } catch (ParseException e) {
             assertThat(e.getMessage(), is(String.format("URI string %s does not start with %s", uri, TCMURI.URI_NAMESPACE)));
@@ -80,7 +80,7 @@ public class TCMURITest {
         final String uri = String.format("tcm:%s#bad", PUBLICATION_ID);
 
         try {
-            new TCMURI().load(uri);
+            new TCMURI(uri);
             fail("Exception expected");
         } catch (ParseException e) {
             assertThat(e.getMessage(), is(String.format("URI %s does not match the pattern", uri)));
@@ -91,8 +91,7 @@ public class TCMURITest {
     build_when_url_only_mandatory_parameters_and_put_default() throws ParseException {
         final String uri = String.format("tcm:%s-%s", PUBLICATION_ID, ITEM_ID);
 
-        TCMURI tcmUri = new TCMURI();
-        tcmUri.load(uri);
+        TCMURI tcmUri = new TCMURI(uri);
 
         assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
         assertThat(tcmUri.getItemId(), is(ITEM_ID));
@@ -105,7 +104,7 @@ public class TCMURITest {
         final String uri = String.format("tcm:%s-%s-%s", "aString", ITEM_ID, ITEM_TYPE);
 
         try {
-            new TCMURI().load(uri);
+            new TCMURI(uri);
             fail("Exception expected");
         } catch (ParseException e) {
             assertThat(e.getMessage(), is(String.format("URI %s does not match the pattern", uri)));

--- a/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
+++ b/dd4t-api/src/test/java/org/dd4t/core/util/TCMURITest.java
@@ -88,7 +88,7 @@ public class TCMURITest {
     }
 
     @Test public void
-    build_with_only_mandatory_parameters_and_put_default() throws ParseException {
+    build_when_url_only_mandatory_parameters_and_put_default() throws ParseException {
         final String uri = String.format("tcm:%s-%s", PUBLICATION_ID, ITEM_ID);
 
         TCMURI tcmUri = new TCMURI();
@@ -148,7 +148,7 @@ public class TCMURITest {
     create_tcmUri_with_builder() throws ParseException {
         final String uri = String.format("tcm:%s-%s-%s-v%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
 
-        TCMURI tcmUri = new TCMURI.Builder().with(uri).create();
+        TCMURI tcmUri = new TCMURI.Builder(uri).create();
 
         assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
         assertThat(tcmUri.getItemId(), is(ITEM_ID));
@@ -161,12 +161,35 @@ public class TCMURITest {
         final String uri = String.format("tcm:%s-%s-%s-v%s", PUBLICATION_ID, ITEM_ID, ITEM_TYPE, VERSION);
         final int version = 4;
 
-        TCMURI tcmUri = new TCMURI.Builder().with(uri).version(version).create();
+        TCMURI tcmUri = new TCMURI.Builder(uri)
+                .version(version)
+                .create();
 
         assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
         assertThat(tcmUri.getItemId(), is(ITEM_ID));
         assertThat(tcmUri.getItemType(), is(ITEM_TYPE));
         assertThat(tcmUri.getVersion(), is(version));
+    }
+
+    @Test public void
+    build_with_only_mandatory_fields_and_default() throws ParseException {
+        TCMURI tcmUri = new TCMURI.Builder(PUBLICATION_ID, ITEM_ID)
+                .create();
+
+        assertThat(tcmUri.getPublicationId(), is(PUBLICATION_ID));
+        assertThat(tcmUri.getItemId(), is(ITEM_ID));
+        assertThat(tcmUri.getItemType(), is(DEFAULT_ITEM_TYPE));
+        assertThat(tcmUri.getVersion(), is(DEFAULT_VERSION));
+    }
+
+    @Test public void
+    create_using_uri_and_version() throws ParseException {
+        final String uri = String.format("tcm:%s-%s-v%s", PUBLICATION_ID, ITEM_ID, VERSION);
+        final int version = 4;
+
+        TCMURI tcmUri = new TCMURI(uri, version);
+        assertThat(tcmUri.getItemType(), is(16));
+        assertThat(tcmUri.getVersion(), is(4));
     }
 
 


### PR DESCRIPTION
The TCMURI can be refactored with Builder pattern in order to use new forms to construct the object using an URI but be able to overwrite optional values.

Also it is covered by unit tests 