### PR TITLE
Renamed the Tridion and Easylicense artifacts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ dd4t-2-java
 1. Download and install Maven: https://maven.apache.org/run-maven/index.html
 2. Install all Tridion dependencies (aka JAR files) in your local Maven repository as these are not available in Maven Central. The general command to do this is:
 
-		mvn -q install:install-file -DgroupId=com.tridion.contentdelivery -DartifactId=cd_broker -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_broker-7.1.0.jar
+		mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_broker -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_broker-7.1.0.jar
 		
 	Repeat for all other Tridion jar files.
 	
@@ -39,42 +39,42 @@ dd4t-2-java
 	A fairly normal setup for a DD4T 2 web application with Tridion dependencies included is: 
 	
 	     <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_ambient</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_broker</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_cache</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_core</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_datalayer</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_dynamic</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_linking</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_model</artifactId>
             <version>${tridion.version}</version>
         </dependency>
@@ -82,7 +82,7 @@ dd4t-2-java
 	Next, Tridion expects the following third party dependencies which are not in Maven Central and therefore have to be installed locally as well:
 	
 		<dependency>
-            <groupId>com.vs</groupId>
+            <groupId>com.vs.ezlicrun</groupId>
             <artifactId>easylicense</artifactId>
             <version>${easylicense-version}</version>
             <scope>runtime</scope>

--- a/dd4t-example-site/pom.xml
+++ b/dd4t-example-site/pom.xml
@@ -44,86 +44,86 @@
 		
 		<!-- Tridion jarfiles (poms from maven4 tridion) -->
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_ambient</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_broker</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_cache</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_core</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_datalayer</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_dynamic</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_linking</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_model</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<!-- Tridion XPM jars (poms by maven4tridion) -->
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_odata</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_odata_types</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_preview_ambient</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_preview_web</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_session</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
 
 		<dependency>
-			<groupId>com.tridion.contentdelivery</groupId>
+			<groupId>com.tridion</groupId>
 			<artifactId>cd_wrapper</artifactId>
 			<version>${tridion.version}</version>
 		</dependency>
@@ -228,9 +228,8 @@
 		</dependency>
 
 		<!-- Closed source third party dependencies (poms from maven4 tridion) -->
-		<!-- TODO: move to groupid com.vs -->
 		<dependency>
-			<groupId>easylicense</groupId>
+			<groupId>com.vs.ezlicrun</groupId>
 			<artifactId>easylicense</artifactId>
 			<version>2.5</version>
 		</dependency>

--- a/dd4t-providers/mvn-install.bat
+++ b/dd4t-providers/mvn-install.bat
@@ -1,0 +1,41 @@
+REM see DD4T dependency naming on https://github.com/dd4t/dd4t-2-java/blob/develop/README.md
+REM TODO remove dependencies not ued by DD4T 2.0
+REM DD4T README has different easylicense artifactId then dd4t-sample site
+
+@echo off
+rem Install Tridion Content Delivery libraries and necessary third-party libraries in the local Maven repository
+
+echo Installing Tridion Content Delivery libraries into the local Maven repository...
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_ambient         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_ambient-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_broker          -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_broker-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_cache           -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_cache-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_core            -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_core-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_datalayer       -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_datalayer-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_dynamic         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_dynamic-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_linking         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_linking-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_model           -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_model-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_session         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_session-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_wrapper         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_wrapper-7.1.0.jar
+
+REM Optional runtime Tridion Content Delivery JARs (for OData/Preview/HTTP Deploy)
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_deployer            -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_deployer-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_upload              -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_upload-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_odata               -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_odata-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_odata_types         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_odata_types-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_preview_web         -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_preview_web-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_preview_webservice  -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_preview_webservice-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_preview_ambient     -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_preview_ambient-7.1.0.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cd_tcdl                -Dversion=7.1.0 -Dpackaging=jar -Dfile=cd_tcdl-7.1.0.jar
+
+echo Installing Tridion Contextual Web Delivery libraries into the local Maven repository...
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cwd_cartridge      -Dversion=7.1.2 -Dpackaging=jar -Dfile=cwd_cartridge-7.1.2.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cwd_engine         -Dversion=7.1.2 -Dpackaging=jar -Dfile=cwd_engine-7.1.2.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cwd_image          -Dversion=7.1.2 -Dpackaging=jar -Dfile=cwd_image-7.1.2.jar
+call mvn -q install:install-file -DgroupId=com.tridion -DartifactId=cwd_resource       -Dversion=7.1.2 -Dpackaging=jar -Dfile=cwd_resource-7.1.2.jar
+
+echo Installing third-party libraries into the local Maven repository...
+call mvn -q install:install-file -DgroupId=com.vs.ezlicrun -DartifactId=easylicense -Dversion=2.5 -Dpackaging=jar -Dfile=easylicense-2.5.jar
+call mvn -q install:install-file -DgroupId=com.microsoft.sqlserver -DartifactId=sqljdbc4 -Dversion=4.0.0 -Dpackaging=jar -Dfile=sqljdbc4-4.0.jar
+
+echo Finished
+pause

--- a/dd4t-providers/pom.xml
+++ b/dd4t-providers/pom.xml
@@ -52,37 +52,37 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_broker</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_cache</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_core</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_datalayer</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_linking</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_model</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_dynamic</artifactId>
             <version>${tridion.version}</version>
         </dependency>

--- a/dd4t-test-spring-web/pom.xml
+++ b/dd4t-test-spring-web/pom.xml
@@ -146,65 +146,65 @@
 
         <!-- Tridion Content Delivery (CD) -->
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_ambient</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_broker</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_cache</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_core</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_datalayer</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <!-- TODO
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_dynamic</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         -->
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_linking</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_model</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_preview_ambient</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_session</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <!-- TODO
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_tcdl</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_wai</artifactId>
             <version>${tridion.version}</version>
         </dependency>
@@ -251,7 +251,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.vs</groupId>
+            <groupId>com.vs.ezlicrun</groupId>
             <artifactId>easylicense</artifactId>
             <version>${easylicense-version}</version>
             <scope>runtime</scope>

--- a/spring-mvc-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/spring-mvc-archetype/src/main/resources/archetype-resources/pom.xml
@@ -205,63 +205,63 @@
 
         <!-- Tridion Content Delivery (CD) -->
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_ambient</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_broker</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_cache</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_core</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_datalayer</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_dynamic</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_linking</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_model</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_preview_ambient</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_session</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <!-- TODO
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_tcdl</artifactId>
             <version>${tridion.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.tridion.contentdelivery</groupId>
+            <groupId>com.tridion</groupId>
             <artifactId>cd_wai</artifactId>
             <version>${tridion.version}</version>
         </dependency>
@@ -309,7 +309,7 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.vs</groupId>
+            <groupId>com.vs.ezlicrun</groupId>
             <artifactId>easylicense</artifactId>
             <version>${easylicense-version}</version>
             <scope>runtime</scope>


### PR DESCRIPTION
DD4T JAVA used a bit different groupIds for the Tridion and Easylicense dependencies. This is aligned in this PR.