### PR TITLE
public constructor for EHCacheProvider to enable Java Spring config

### DIFF
--- a/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
+++ b/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
@@ -68,7 +68,7 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator, 
     @Resource
     private PropertiesService propertiesService;
 
-    EHCacheProvider () {
+    public EHCacheProvider () {
         LOG.debug("Starting cache provider");
     }
 


### PR DESCRIPTION
It's not possible to configure Spring context using Java-based approach and no XML without publicly available constructors/methods to instantiate a bean. The easiest way is to create a public construstor