### PR TITLE
Multithreading issue: update CacheElement expiry only "after" setting it on the cache.

### DIFF
--- a/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
+++ b/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
@@ -170,7 +170,6 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator, 
             LOG.error("Cache configuration is invalid! NOT Caching. Check EH Cache configuration.");
             return;
         }
-        cacheElement.setExpired(false);
         Element element = new Element(key, cacheElement);
         element.setTimeToLive(cacheTTL);
         if (cache.isKeyInCache(key)) {
@@ -178,6 +177,7 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator, 
         } else {
             cache.put(element);
         }
+        cacheElement.setExpired(false);
     }
 
     /**

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/BinaryFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/BinaryFactoryImpl.java
@@ -68,7 +68,6 @@ public class BinaryFactoryImpl extends BaseFactory implements BinaryFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         binary = binaryProvider.getBinaryByURI(tcmUri);
                         cacheElement.setPayload(binary);
@@ -77,8 +76,8 @@ public class BinaryFactoryImpl extends BaseFactory implements BinaryFactory {
                         LOG.debug("Added binary with uri: {} to cache", tcmUri);
                     } catch (ParseException e) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(tcmUri, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException(e);
                     }
                 } else {
@@ -116,7 +115,6 @@ public class BinaryFactoryImpl extends BaseFactory implements BinaryFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         binary = binaryProvider.getBinaryByURL(url, publicationId);
                         cacheElement.setPayload(binary);

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/ComponentPresentationFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/ComponentPresentationFactoryImpl.java
@@ -94,15 +94,14 @@ public class ComponentPresentationFactoryImpl extends BaseFactory implements Com
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
 
-                    cacheElement.setExpired(false);
                     String rawComponentPresentation;
                     rawComponentPresentation = componentPresentationProvider.getDynamicComponentPresentation(componentId, templateId, publicationId);
 
                     if (rawComponentPresentation == null) {
 
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(key, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException(String.format("Could not find DCP with componentURI: %s and templateURI: %s", componentURI, templateURI));
                     }
 

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
@@ -70,7 +70,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     String pageSource;
                     ProviderResultItem<String> resultItem;
                     TCMURI tcmUri;
@@ -133,7 +132,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired() || cacheElement.getPayload() == null) {
-                    cacheElement.setExpired(false);
                     String pageSource;
                     ProviderResultItem<String> resultItem;
                     resultItem = pageProvider.getPageByURL(url, publicationId);
@@ -141,8 +139,8 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
 
                     if (StringUtils.isEmpty(pageSource)) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("Page with url: " + url + " not found.");
                     }
 
@@ -210,13 +208,12 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     page = pageProvider.getPageContentByURL(url, publicationId);
 
                     if (page == null || page.length() == 0) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("XML Page with url: " + url + " not found.");
                     }
 
@@ -261,7 +258,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     try {
                         pageSource = pageProvider.getPageContentById(tcmId);
@@ -272,8 +268,8 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
 
                     if (StringUtils.isEmpty(pageSource)) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("Unable to find page by id " + tcmId);
                     }
 

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
@@ -74,7 +74,6 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         String taxonomySource = taxonomyProvider.getTaxonomyByURI(taxonomyURI, true);
                         if (taxonomySource == null || taxonomySource.length() == 0) {
@@ -137,7 +136,6 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         String taxonomySource = taxonomyProvider.getTaxonomyFilterBySchema(taxonomyURI, schemaURI);
                         if (taxonomySource == null || taxonomySource.length() == 0) {

--- a/dd4t-providers-common/src/main/java/org/dd4t/providers/AbstractPublicationProvider.java
+++ b/dd4t-providers-common/src/main/java/org/dd4t/providers/AbstractPublicationProvider.java
@@ -85,7 +85,6 @@ public abstract class AbstractPublicationProvider extends BaseBrokerProvider imp
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     final PageMeta pageMeta = loadPageMetaByConcreteFactory(url);
                     if (pageMeta != null) {

--- a/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
+++ b/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
@@ -244,11 +244,8 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
-
 
                     TCMURI tcmuri = null;
-
                     try {
                         final PageMeta pageMeta = getPageMetaByURL(url,publicationId);
                         if (pageMeta != null) {

--- a/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
+++ b/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
@@ -236,7 +236,6 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     final PublicationCriteria publicationCriteria = new PublicationCriteria(publicationId);
                     final PageURLCriteria pageURLCriteria = new PageURLCriteria(url);
 


### PR DESCRIPTION
If you set the expiry of the cache element before updating it on the cache other threads could still read the old value (while they where instructed the element was not expired).
This change sets the expiry after it has been updated / set on the cache.