### PR TITLE
Hotfix/multithreading cache issue

### DIFF
--- a/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
+++ b/dd4t-caching/src/main/java/org/dd4t/core/providers/EHCacheProvider.java
@@ -170,7 +170,6 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator, 
             LOG.error("Cache configuration is invalid! NOT Caching. Check EH Cache configuration.");
             return;
         }
-        cacheElement.setExpired(false);
         Element element = new Element(key, cacheElement);
         element.setTimeToLive(cacheTTL);
         if (cache.isKeyInCache(key)) {
@@ -196,7 +195,6 @@ public class EHCacheProvider implements PayloadCacheProvider, CacheInvalidator, 
             LOG.error("Cache configuration is invalid! NOT Caching. Check EH Cache configuration.");
             return;
         }
-        cacheElement.setExpired(false);
         Element element = cache.get(key);
         if (element == null) {
             element = new Element(key, cacheElement);

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/BinaryFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/BinaryFactoryImpl.java
@@ -68,17 +68,17 @@ public class BinaryFactoryImpl extends BaseFactory implements BinaryFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         binary = binaryProvider.getBinaryByURI(tcmUri);
                         cacheElement.setPayload(binary);
                         TCMURI binaryURI = new TCMURI(tcmUri);
                         cacheProvider.storeInItemCache(tcmUri, cacheElement, binaryURI.getPublicationId(), binaryURI.getItemId());
+                        cacheElement.setExpired(false);
                         LOG.debug("Added binary with uri: {} to cache", tcmUri);
                     } catch (ParseException e) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(tcmUri, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException(e);
                     }
                 } else {
@@ -116,13 +116,13 @@ public class BinaryFactoryImpl extends BaseFactory implements BinaryFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         binary = binaryProvider.getBinaryByURL(url, publicationId);
                         cacheElement.setPayload(binary);
 
                         TCMURI tcmUri = new TCMURI(binary.getId());
                         cacheProvider.storeInItemCache(key, cacheElement, tcmUri.getPublicationId(), tcmUri.getItemId());
+                        cacheElement.setExpired(false);
                         LOG.debug("Added binary with url: {} to cache", url);
                     } catch (ParseException e) {
                         throw new ItemNotFoundException(e);

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/ComponentPresentationFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/ComponentPresentationFactoryImpl.java
@@ -94,15 +94,14 @@ public class ComponentPresentationFactoryImpl extends BaseFactory implements Com
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
 
-                    cacheElement.setExpired(false);
                     String rawComponentPresentation;
                     rawComponentPresentation = componentPresentationProvider.getDynamicComponentPresentation(componentId, templateId, publicationId);
 
                     if (rawComponentPresentation == null) {
 
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(key, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException(String.format("Could not find DCP with componentURI: %s and templateURI: %s", componentURI, templateURI));
                     }
 
@@ -114,6 +113,7 @@ public class ComponentPresentationFactoryImpl extends BaseFactory implements Com
                     this.executeProcessors(componentPresentation.getComponent(), RunPhase.BEFORE_CACHING, getRequestContext());
                     cacheElement.setPayload(componentPresentation);
                     cacheProvider.storeInItemCache(key, cacheElement, publicationId, componentId);
+                    cacheElement.setExpired(false);
                     LOG.debug("Added component with uri: {} and template: {} to cache", componentURI, templateURI);
 
                 } else {

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
@@ -86,6 +86,7 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
                     if (StringUtils.isEmpty(pageSource)) {
                         cacheElement.setPayload(null);
                         cacheProvider.storeInItemCache(uri, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("Unable to find page by id " + uri);
                     }
 

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/PageFactoryImpl.java
@@ -70,7 +70,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     String pageSource;
                     ProviderResultItem<String> resultItem;
                     TCMURI tcmUri;
@@ -100,6 +99,7 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
                     cacheElement.setPayload(page);
 
                     cacheProvider.storeInItemCache(uri, cacheElement, tcmUri.getPublicationId(), tcmUri.getItemId());
+                    cacheElement.setExpired(false);
                     LOG.debug("Added page with uri: {} to cache", uri);
 
                 } else {
@@ -133,7 +133,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired() || cacheElement.getPayload() == null) {
-                    cacheElement.setExpired(false);
                     String pageSource;
                     ProviderResultItem<String> resultItem;
                     resultItem = pageProvider.getPageByURL(url, publicationId);
@@ -141,8 +140,8 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
 
                     if (StringUtils.isEmpty(pageSource)) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("Page with url: " + url + " not found.");
                     }
 
@@ -158,6 +157,7 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
                         this.executeProcessors(page, RunPhase.BEFORE_CACHING, getRequestContext());
                         cacheElement.setPayload(page);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement, publicationId, tcmUri.getItemId());
+                        cacheElement.setExpired(false);
 
                         LOG.debug("Added page with uri: {} and publicationId: {} to cache", url, publicationId);
                     } catch (ParseException e) {
@@ -212,18 +212,18 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     page = pageProvider.getPageContentByURL(url, publicationId);
 
                     if (page == null || page.length() == 0) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("XML Page with url: " + url + " not found.");
                     }
 
                     cacheElement.setPayload(page);
                     cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                    cacheElement.setExpired(false);
 
                     LOG.debug("Added XML page with uri: {} and publicationId: {} to cache", url, publicationId);
                 } else {
@@ -263,7 +263,6 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     try {
                         pageSource = pageProvider.getPageContentById(tcmId);
@@ -274,13 +273,14 @@ public class PageFactoryImpl extends BaseFactory implements PageFactory {
 
                     if (StringUtils.isEmpty(pageSource)) {
                         cacheElement.setPayload(null);
-                        cacheElement.setExpired(true);
                         cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                        cacheElement.setExpired(true);
                         throw new ItemNotFoundException("Unable to find page by id " + tcmId);
                     }
 
                     cacheElement.setPayload(pageSource);
                     cacheProvider.storeInItemCache(cacheKey, cacheElement);
+                    cacheElement.setExpired(false);
                 } else {
                     LOG.debug("Return a page with uri: {} from cache", tcmId);
                     pageSource = cacheElement.getPayload();

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
@@ -79,6 +79,7 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
                         if (taxonomySource == null || taxonomySource.length() == 0) {
                             cacheElement.setPayload(null);
                             cacheProvider.storeInItemCache(taxonomyURI, cacheElement);
+                            cacheElement.setExpired(true);
                             throw new ItemNotFoundException(String.format("Taxonomy with uri: %s not found.", taxonomyURI));
                         }
 
@@ -142,6 +143,7 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
                         if (taxonomySource == null || taxonomySource.length() == 0) {
                             cacheElement.setPayload(null);
                             cacheProvider.storeInItemCache(taxonomyURI, cacheElement);
+                            cacheElement.setExpired(true);
                             throw new ItemNotFoundException("Taxonomy with uri: " + taxonomyURI + " not found.");
                         }
 
@@ -155,6 +157,7 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
                     } catch (ItemNotFoundException e) {
                         cacheElement.setPayload(null);
                         cacheProvider.storeInItemCache(taxonomyURI, cacheElement);
+                        cacheElement.setExpired(true);
                         LOG.error(e.getLocalizedMessage(), e);
                         throw new IOException("Taxonomy with uri: " + taxonomyURI + " not found.");
                     } catch (ParseException | SerializationException e) {

--- a/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/factories/impl/TaxonomyFactoryImpl.java
@@ -74,7 +74,6 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         String taxonomySource = taxonomyProvider.getTaxonomyByURI(taxonomyURI, true);
                         if (taxonomySource == null || taxonomySource.length() == 0) {
@@ -88,6 +87,7 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
 
                         TCMURI tcmUri = new TCMURI(taxonomyURI);
                         cacheProvider.storeInItemCache(taxonomyURI, cacheElement, tcmUri.getPublicationId(), tcmUri.getItemId());
+                        cacheElement.setExpired(false);
                         LOG.debug("Added taxonomy with uri: {} to cache", taxonomyURI);
                     } catch (ItemNotFoundException | ParseException | SerializationException e) {
                         LOG.error(NOT_FOUND_ERROR_MESSAGE, taxonomyURI, e);
@@ -137,7 +137,6 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     try {
                         String taxonomySource = taxonomyProvider.getTaxonomyFilterBySchema(taxonomyURI, schemaURI);
                         if (taxonomySource == null || taxonomySource.length() == 0) {
@@ -151,6 +150,7 @@ public class TaxonomyFactoryImpl extends BaseFactory implements TaxonomyFactory 
 
                         TCMURI tcmUri = new TCMURI(taxonomyURI);
                         cacheProvider.storeInItemCache(key, cacheElement, tcmUri.getPublicationId(), tcmUri.getItemId());
+                        cacheElement.setExpired(false);
                         LOG.debug("Added taxonomy with uri: {} and schema: {} to cache", taxonomyURI, schemaURI);
                     } catch (ItemNotFoundException e) {
                         cacheElement.setPayload(null);

--- a/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/AbstractPublicationProvider.java
+++ b/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/AbstractPublicationProvider.java
@@ -91,9 +91,9 @@ public abstract class AbstractPublicationProvider extends BaseBrokerProvider imp
 
                     publicationMeta = loadPublicationMetaByConcreteFactory(publicationId);
                     if (publicationMeta != null) {
-                        cacheElement.setExpired(false);
                         cacheElement.setPayload(publicationMeta);
                         cacheProvider.storeInItemCache(key, cacheElement);
+                        cacheElement.setExpired(false);
                         LOG.debug("Stored Publication Meta with key: {} in cache", key);
                     } else {
                         LOG.warn("No Publication Meta found for publication Id: {}", publicationId);

--- a/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
+++ b/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
@@ -234,11 +234,8 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
-
 
                     TCMURI tcmuri = null;
-
                     try {
                         final PageMeta pageMeta = getPageMetaByURL(url,publicationId);
                         if (pageMeta != null) {
@@ -252,10 +249,12 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
                     if (result == 1) {
                         cacheElement.setPayload(result);
                         cacheProvider.storeInItemCache(key, cacheElement, tcmuri.getPublicationId(), tcmuri.getItemId());
+                        cacheElement.setExpired(false);
                     } else {
                         result = 0;
                         cacheElement.setPayload(result);
                         cacheProvider.storeInItemCache(key, cacheElement);
+                        cacheElement.setExpired(false);
                     }
                     LOG.debug("Stored Page exist check with key: {} in cache", key);
                 } else {

--- a/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPublicationProvider.java
+++ b/dd4t-providers-web8/src/main/java/org/dd4t/providers/impl/BrokerPublicationProvider.java
@@ -85,7 +85,6 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     final PageMeta pageMeta = loadPageMetaByConcreteFactory(url);
                     if (pageMeta != null) {
@@ -97,6 +96,7 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
 
                     cacheElement.setPayload(result);
                     cacheProvider.storeInItemCache(key, cacheElement);
+                    cacheElement.setExpired(false);
                     LOG.debug("Stored Publication Id with key: {} in cache", key);
                 } else {
                     LOG.debug("Fetched a Publication Id with key: {} from cache", key);
@@ -124,7 +124,6 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     final BinaryMeta binaryMeta = loadBinaryMetaByConcreteFactory(fullUrl);
                     if (binaryMeta != null) {
@@ -136,6 +135,7 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
 
                     cacheElement.setPayload(result);
                     cacheProvider.storeInItemCache(key, cacheElement);
+                    cacheElement.setExpired(false);
                     LOG.debug("Stored Publication Id with key: {} in cache", key);
                 } else {
                     LOG.debug("Fetched a Publication Id with key: {} from cache", key);

--- a/dd4t-providers/src/main/java/org/dd4t/providers/impl/AbstractPublicationProvider.java
+++ b/dd4t-providers/src/main/java/org/dd4t/providers/impl/AbstractPublicationProvider.java
@@ -92,9 +92,9 @@ public abstract class AbstractPublicationProvider extends BaseBrokerProvider imp
 
                     publicationMeta = loadPublicationMetaByConcreteFactory(publicationId);
                     if (publicationMeta != null) {
-                        cacheElement.setExpired(false);
                         cacheElement.setPayload(publicationMeta);
                         cacheProvider.storeInItemCache(key, cacheElement);
+                        cacheElement.setExpired(false);
                         LOG.debug("Stored Publication Meta with key: {} in cache", key);
                     } else {
                         LOG.warn("No Publication Meta found for publication Id: {}", publicationId);

--- a/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
+++ b/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPageProvider.java
@@ -236,7 +236,6 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
                     final PublicationCriteria publicationCriteria = new PublicationCriteria(publicationId);
                     final PageURLCriteria pageURLCriteria = new PageURLCriteria(url);
 
@@ -251,10 +250,12 @@ public class BrokerPageProvider extends BaseBrokerProvider implements PageProvid
                             TCMURI tcmuri = new TCMURI(results[0]);
                             cacheElement.setPayload(result);
                             cacheProvider.storeInItemCache(key, cacheElement, tcmuri.getPublicationId(), tcmuri.getItemId());
+                            cacheElement.setExpired(false);
                         } else {
                             result = 0;
                             cacheElement.setPayload(result);
                             cacheProvider.storeInItemCache(key, cacheElement);
+                            cacheElement.setExpired(false);
                         }
                     } catch (StorageException | ParseException e) {
                         LOG.error(e.getLocalizedMessage(), e);

--- a/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPublicationProvider.java
+++ b/dd4t-providers/src/main/java/org/dd4t/providers/impl/BrokerPublicationProvider.java
@@ -71,7 +71,6 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     final PageMeta pageMeta = loadPageMetaByConcreteFactory(url);
                     if (pageMeta != null) {
@@ -83,6 +82,7 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
 
                     cacheElement.setPayload(result);
                     cacheProvider.storeInItemCache(key, cacheElement);
+                    cacheElement.setExpired(false);
                     LOG.debug("Stored Publication Id with key: {} in cache", key);
                 } else {
                     LOG.debug("Fetched a Publication Id with key: {} from cache", key);
@@ -108,7 +108,6 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
             //noinspection SynchronizationOnLocalVariableOrMethodParameter
             synchronized (cacheElement) {
                 if (cacheElement.isExpired()) {
-                    cacheElement.setExpired(false);
 
                     final BinaryMeta binaryMeta = loadBinaryMetaByConcreteFactory(fullUrl);
                     if (binaryMeta != null) {
@@ -120,6 +119,7 @@ public class BrokerPublicationProvider extends AbstractPublicationProvider imple
 
                     cacheElement.setPayload(result);
                     cacheProvider.storeInItemCache(key, cacheElement);
+                    cacheElement.setExpired(false);
                     LOG.debug("Stored Publication Id with key: {} in cache", key);
                 } else {
                     LOG.debug("Fetched a Publication Id with key: {} from cache", key);


### PR DESCRIPTION
Refactored the code a little bit to make sure the expiry field will get set only once.
When multiple thread access this field you want to make sure it's set only once and not switch a couple of lines later.

The latest commit: I wanted to discuss upon: 1277a76
It's about a couple of places where element was set to not be expired, where actually we are throwing itemnotfound exceptions.

Should we be doing that, is that on purpose? Or are we going to be in-line with other places where items that are not found are marked as expired in the cache?
