### PR TITLE
HTML page source contains both a blank href and a href with the publi…

### DIFF
--- a/dd4t-core/src/main/java/org/dd4t/core/util/RichTextUtils.java
+++ b/dd4t-core/src/main/java/org/dd4t/core/util/RichTextUtils.java
@@ -63,7 +63,14 @@ public class RichTextUtils {
                         if (StringUtils.isNotEmpty(resolvedLink)) {
                             link.attr(XLINK_HREF, contextPathToUse + resolvedLink);
                         } else {
-                            link.attr(XLINK_HREF, "");
+                            if (link.hasAttr("href") == true)
+							{
+								link.removeAttr(XLINK_HREF);
+							}
+							else
+							{
+								link.attr(XLINK_HREF, "");
+							}
                         }
                     }
                 }


### PR DESCRIPTION
…shed binary URL when component linking to a MM component in an RTF field. This occurs because the Tridion templates render both the xlink containing the TCM ID and also a href with the published binary URL. This commit updates the code to only write out a blank href if there is not already a href present.