### PR TITLE
Made PropertiesServiceImpl.java constructor public so you can constru…

### DIFF
--- a/dd4t-mvc-support/src/main/java/org/dd4t/mvc/utils/PropertiesServiceImpl.java
+++ b/dd4t-mvc-support/src/main/java/org/dd4t/mvc/utils/PropertiesServiceImpl.java
@@ -34,7 +34,7 @@ public class PropertiesServiceImpl extends PropertiesServiceBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(PropertiesServiceImpl.class);
 
-    private PropertiesServiceImpl () {
+    public PropertiesServiceImpl () {
     }
 
     @Override


### PR DESCRIPTION
…ct it

Most utils in this package are static utils and have private constructors, this class isn't though and actually needs to be instantiated.