### PR TITLE
Lower some log levels

### DIFF
--- a/dd4t-databind/src/main/java/org/dd4t/databind/builder/json/JsonDataBinder.java
+++ b/dd4t-databind/src/main/java/org/dd4t/databind/builder/json/JsonDataBinder.java
@@ -74,7 +74,7 @@ public class JsonDataBinder extends BaseDataBinder implements DataBinder {
      * Note: this class needs to be initialized by Spring!
      */
     public JsonDataBinder () {
-        LOG.info("Creating a JsonDataBinder instance.");
+        LOG.debug("Creating a JsonDataBinder instance.");
     }
 
     @Override
@@ -172,7 +172,7 @@ public class JsonDataBinder extends BaseDataBinder implements DataBinder {
                     models.put(modelName, buildModel(source, modelClass, templateUri));
                 }
             } else {
-                LOG.warn("Could not load Model Class for key: {}", modelName);
+                LOG.debug("Could not load Model Class for key: {}", modelName);
             }
         }
         return models;

--- a/dd4t-databind/src/main/java/org/dd4t/databind/builder/json/JsonDataBinder.java
+++ b/dd4t-databind/src/main/java/org/dd4t/databind/builder/json/JsonDataBinder.java
@@ -74,7 +74,6 @@ public class JsonDataBinder extends BaseDataBinder implements DataBinder {
      * Note: this class needs to be initialized by Spring!
      */
     public JsonDataBinder () {
-        LOG.debug("Creating a JsonDataBinder instance.");
     }
 
     @Override


### PR DESCRIPTION
Does creating a new instance of `JsonDataBinder` really justify an info log message? Personally I don't think it does - hence the first change.

The second change reduces a warn to a debug, because a warning should indicate some kind of problem, but this message happens even when the view models are setup correctly (I have `@ViewModel(rootElementNames = "myElement")`, so I get a redundant warning like `Could not load Model Class for key: my-element`).