### PR TITLE
Performance fixes

### DIFF
--- a/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/FieldSetImpl.java
+++ b/dd4t-core/src/main/java/org/dd4t/contentmodel/impl/FieldSetImpl.java
@@ -73,7 +73,7 @@ public class FieldSetImpl implements FieldSet, Serializable {
 
         try {
             // The basefield annotations will map the fields to concrete types
-            BaseField b = JsonDataBinder.getGenericMapper().readValue(embeddedField.toString(), BaseField.class);
+            BaseField b = JsonDataBinder.getGenericMapper().treeToValue(embeddedField, BaseField.class);
             fieldSet.put(fieldKey, b);
         } catch (IOException e) {
             LOG.error("Error deserializing FieldSet.", e);

--- a/dd4t-databind/src/main/java/org/dd4t/databind/serializers/json/ComponentPresentationDeserializer.java
+++ b/dd4t-databind/src/main/java/org/dd4t/databind/serializers/json/ComponentPresentationDeserializer.java
@@ -88,7 +88,7 @@ public class ComponentPresentationDeserializer extends StdDeserializer<Component
             final Map.Entry<String, JsonNode> element = fields.next();
             final String key = element.getKey();
 
-            LOG.trace(element.getKey() + "  " + element.getValue().toString());
+            LOG.trace("{} {}", element.getKey(), element.getValue());
 
             if (key.equalsIgnoreCase(DataBindConstants.COMPONENT_NODE_NAME)) {
                 LOG.debug("Fishing out Component Data");


### PR DESCRIPTION
In my application, where DD4T is parsing about 800kb of JSON, these changes reduce the time needed from about 3 seconds to about 600ms.